### PR TITLE
Fix issues with ULib.ucl.query calls before PlayerInitialSpawn

### DIFF
--- a/lua/ulib/shared/sh_ucl.lua
+++ b/lua/ulib/shared/sh_ucl.lua
@@ -68,8 +68,11 @@ function ucl.query( ply, access, hide )
 	access = access:lower()
 
 	local id64 = ply:SteamID64()
-
-	if not ucl.authed[ id64 ] then return error( "[ULIB] Unauthed player" ) end -- Sanity check
+	
+	if not ucl.authed[ id64 ] then -- If we use the query in PlayerInitialSpawn before PlayerAuthed or it was not called or player is unauthed
+		ply:UniqueID() -- Oddly enough, it calls PlayerAuthed
+		if not ucl.authed[ id64 ] then return error( "[ULIB] Unauthed player" ) end -- Sanity check
+	end
 	local playerInfo = ucl.authed[ id64 ]
 
 	-- First check the player's info


### PR DESCRIPTION
PlayerAuthed is called only manually or when calling UniqueID for the first time. If you try to find out what players or what permissions a player has before calling PlayerAuthed, it will give an error that the player is not authorized = everything will break